### PR TITLE
Install tokei from cargo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM public.ecr.aws/lambda/ruby:2.7 AS build
 
-RUN yum install -y tar gzip
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
-RUN curl -L -o /tmp/tokei.tar.gz https://github.com/XAMPPRocky/tokei/releases/download/v12.1.2/tokei-x86_64-unknown-linux-musl.tar.gz && \
-    tar -xvf /tmp/tokei.tar.gz -C /usr/bin
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN yum install gcc -y
+
+RUN cargo install --git https://github.com/XAMPPRocky/tokei.git tokei
 
 FROM public.ecr.aws/lambda/ruby:2.7 AS runtime
 
-COPY --from=build /usr/bin/tokei /usr/bin/tokei
+COPY --from=build /root/.cargo/bin/tokei /usr/bin/tokei
 
 RUN yum install -y gcc make
 


### PR DESCRIPTION
We need to install tokei from cargo as the library author doesn't intend to release new versions via github, and we need the latest 
version for Unison support.

CC @rlmark