### PR TITLE
Add special Haskell support

### DIFF
--- a/tests/haskell/multiple-files/anagram.cabal
+++ b/tests/haskell/multiple-files/anagram.cabal
@@ -1,0 +1,37 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           anagram
+version:        1.4.0.8
+build-type:     Simple
+
+library
+  exposed-modules:
+      Anagram
+  other-modules:
+      Helper
+      Paths_anagram
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base
+    , multiset
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Tests.hs
+  other-modules:
+      Paths_anagram
+  hs-source-dirs:
+      test
+  build-depends:
+      anagram
+    , base
+    , hspec
+    , multiset
+  default-language: Haskell2010

--- a/tests/haskell/multiple-files/expected_response.json
+++ b/tests/haskell/multiple-files/expected_response.json
@@ -1,9 +1,9 @@
 {
-    "statusCode": 200,
-    "statusDescription": "200 OK",
-    "headers": {
-        "Content-Type": "application/json"
-    },
-    "isBase64Encoded": false,
-    "body": "{\"counts\":{\"code\":10,\"blanks\":5,\"comments\":1},\"files\":[\"src/Anagram.hs\",\"src/Helper.hs\"]}"
+  "statusCode": 200,
+  "statusDescription": "200 OK",
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "isBase64Encoded": false,
+  "body": "{\"counts\":{\"code\":10,\"blanks\":5,\"comments\":1},\"files\":[\"src/Anagram.hs\",\"src/Helper.hs\"]}"
 }

--- a/tests/haskell/multiple-files/expected_response.json
+++ b/tests/haskell/multiple-files/expected_response.json
@@ -1,0 +1,9 @@
+{
+    "statusCode": 200,
+    "statusDescription": "200 OK",
+    "headers": {
+        "Content-Type": "application/json"
+    },
+    "isBase64Encoded": false,
+    "body": "{\"counts\":{\"code\":10,\"blanks\":5,\"comments\":1},\"files\":[\"src/Anagram.hs\",\"src/Helper.hs\"]}"
+}

--- a/tests/haskell/multiple-files/package.yaml
+++ b/tests/haskell/multiple-files/package.yaml
@@ -1,0 +1,22 @@
+name: anagram
+version: 1.4.0.8
+
+dependencies:
+  - base
+  - multiset
+
+library:
+  exposed-modules: Anagram
+  source-dirs: src
+  ghc-options: -Wall
+  # dependencies:
+  # - foo       # List here the packages you
+  # - bar       # want to use in your solution.
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - anagram
+      - hspec

--- a/tests/haskell/multiple-files/src/Anagram.hs
+++ b/tests/haskell/multiple-files/src/Anagram.hs
@@ -1,0 +1,6 @@
+module Anagram (anagramsFor) where
+
+import Helper (isProperAnagramOf)
+
+anagramsFor :: String -> [String] -> [String]
+anagramsFor = filter . isProperAnagramOf

--- a/tests/haskell/multiple-files/src/Helper.hs
+++ b/tests/haskell/multiple-files/src/Helper.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE ViewPatterns #-}
+
+module Helper (isProperAnagramOf) where
+
+import Data.Char (toLower)
+import Data.MultiSet (fromList)
+
+isProperAnagramOf :: String -> String -> Bool
+isProperAnagramOf (map toLower -> s) (map toLower -> t) =
+  s /= t && fromList s == fromList t

--- a/tests/haskell/single-file/anagram.cabal
+++ b/tests/haskell/single-file/anagram.cabal
@@ -1,0 +1,36 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           anagram
+version:        1.4.0.8
+build-type:     Simple
+
+library
+  exposed-modules:
+      Anagram
+  other-modules:
+      Paths_anagram
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      base
+    , multiset
+  default-language: Haskell2010
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: Tests.hs
+  other-modules:
+      Paths_anagram
+  hs-source-dirs:
+      test
+  build-depends:
+      anagram
+    , base
+    , hspec
+    , multiset
+  default-language: Haskell2010

--- a/tests/haskell/single-file/expected_response.json
+++ b/tests/haskell/single-file/expected_response.json
@@ -1,0 +1,9 @@
+{
+    "statusCode": 200,
+    "statusDescription": "200 OK",
+    "headers": {
+        "Content-Type": "application/json"
+    },
+    "isBase64Encoded": false,
+    "body": "{\"counts\":{\"code\":9,\"blanks\":3,\"comments\":0},\"files\":[\"src/Anagram.hs\"]}"
+}

--- a/tests/haskell/single-file/expected_response.json
+++ b/tests/haskell/single-file/expected_response.json
@@ -5,5 +5,5 @@
         "Content-Type": "application/json"
     },
     "isBase64Encoded": false,
-    "body": "{\"counts\":{\"code\":9,\"blanks\":3,\"comments\":0},\"files\":[\"src/Anagram.hs\"]}"
+    "body": "{\"counts\":{\"code\":8,\"blanks\":3,\"comments\":1},\"files\":[\"src/Anagram.hs\"]}"
 }

--- a/tests/haskell/single-file/expected_response.json
+++ b/tests/haskell/single-file/expected_response.json
@@ -1,9 +1,9 @@
 {
-    "statusCode": 200,
-    "statusDescription": "200 OK",
-    "headers": {
-        "Content-Type": "application/json"
-    },
-    "isBase64Encoded": false,
-    "body": "{\"counts\":{\"code\":8,\"blanks\":3,\"comments\":1},\"files\":[\"src/Anagram.hs\"]}"
+  "statusCode": 200,
+  "statusDescription": "200 OK",
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "isBase64Encoded": false,
+  "body": "{\"counts\":{\"code\":8,\"blanks\":3,\"comments\":1},\"files\":[\"src/Anagram.hs\"]}"
 }

--- a/tests/haskell/single-file/package.yaml
+++ b/tests/haskell/single-file/package.yaml
@@ -1,0 +1,22 @@
+name: anagram
+version: 1.4.0.8
+
+dependencies:
+  - base
+  - multiset
+
+library:
+  exposed-modules: Anagram
+  source-dirs: src
+  ghc-options: -Wall
+  # dependencies:
+  # - foo       # List here the packages you
+  # - bar       # want to use in your solution.
+
+tests:
+  test:
+    main: Tests.hs
+    source-dirs: test
+    dependencies:
+      - anagram
+      - hspec

--- a/tests/haskell/single-file/src/Anagram.hs
+++ b/tests/haskell/single-file/src/Anagram.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE ViewPatterns #-}
+
+module Anagram (anagramsFor) where
+
+import Data.Char (toLower)
+import Data.MultiSet (fromList)
+
+anagramsFor :: String -> [String] -> [String]
+anagramsFor = filter . isProperAnagramOf
+  where
+    isProperAnagramOf (map toLower -> s) (map toLower -> t) =
+      s /= t && fromList s == fromList t

--- a/tracks/haskell.ignore
+++ b/tracks/haskell.ignore
@@ -1,0 +1,2 @@
+*.cabal
+package.yaml


### PR DESCRIPTION
I think the line count should not include project files. This change adds filters for `package.yaml` and `*.cabal` files. The latter are not submitted by default, but some students might explicitly submit them anyway.

It turns out that `tokei` miscounts [pragma's ](https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/pragmas.html) as comments. The tests follow `tokei`'s output instead of the 'right' one.