### PR TITLE
ci: speedup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+        with:
+          install: true
+
+      - name: Build Docker image and store in cache
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
+        with:
+          context: .
+          push: false
+          load: true
+          tags: exercism/lines-of-code-counter
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Run Tests in Docker
         run: bin/run-tests-in-docker.sh


### PR DESCRIPTION
This will cache the Docker build layers, which greatly helps as we're compiling tokei